### PR TITLE
Fix export

### DIFF
--- a/src/bl/XactnTypeBL.js
+++ b/src/bl/XactnTypeBL.js
@@ -45,7 +45,7 @@ export function getXactnTypeDetail(xactn,outputArrayRow){
     xactnTypeDetail = xactnTypes[0].XactnTypeDetail;
   } else if(xactn?.tx?.token_transfer?.memo ) {
     let memo = hexToAscii(xactn.tx.token_transfer.memo.substring(2)).trim();
-    xactnTypeDetail = memo.length > 0 ? `"${memo}"`: '';
+    xactnTypeDetail = memo.length > 0 ? `'${memo}'`: '';
     console.log(xactnTypeDetail, memo, xactn.tx.token_transfer.memo)
   } else if(xactn.tx?.contract_call?.function_name) {
     xactnTypeDetail = xactn.tx?.contract_call?.function_name;


### PR DESCRIPTION
The latest update introduced problems with quotes in the export.

This PR fixes this by using `'` instead of `"` to mark memos